### PR TITLE
DOC: Added examples for float_format in to_csv documentation

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3878,6 +3878,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> import os  # doctest: +SKIP
         >>> os.makedirs("folder/subfolder", exist_ok=True)  # doctest: +SKIP
         >>> df.to_csv("folder/subfolder/out.csv")  # doctest: +SKIP
+        Format floating-point numbers using float_format:
+            - Format floats to two decimal places:
+              >>> df.to_csv("out1.csv", float_format="%.2f")  # doctest: +SKIP
+            - Use scientific notation:
+              >>> df.to_csv("out2.csv", float_format="{:.2e}".format)  # doctest: +SKIP
         """
         df = self if isinstance(self, ABCDataFrame) else self.to_frame()
 


### PR DESCRIPTION
-closes #60432

This PR adds examples for the float_format parameter in the to_csv documentation.